### PR TITLE
[AE-3354] Match scrapper stops due to a TCP connection timeout

### DIFF
--- a/tastypie_client/core.py
+++ b/tastypie_client/core.py
@@ -331,11 +331,15 @@ class Api(object):
     def _parse_resources(self, resources):
         return map(self._parse_resource, resources)
 
-    def _get(self, type=None, id=None, **kw):
+    def _get(self, type=None, id=None, timeout=None, **kw):
         """Do a HTTP GET request"""
 
         url = self._get_url(type, id, **kw)
-        response = requests.get(url, auth=self._auth, params=self._params, verify=self._verify)
+        if timeout:
+            response = requests.get(url, auth=self._auth, params=self._params, verify=self._verify, timeout=timeout)
+        else:
+            response = requests.get(url, auth=self._auth, params=self._params, verify=self._verify)
+
         if response.status_code != 200:
             raise BadHttpStatus(response)
         raw_data = response.content


### PR DESCRIPTION
**https://threatstream.atlassian.net/browse/AE-3354**

**Background:**
During testing it was noted that if a TCP connection times out for some reason that Match scrapper can end up getting stuck (worker process 'hangs') because there is no timeout in place.

**Solution:**
Add in a timeout to the tastypie client API _get call to ensure that if a timeout is passed in then it is used. The code has been written in such a way that if a timeout is not passed in then there is no change to existing functionality.

**Testing:**
In progress